### PR TITLE
Add michael-mccarthy-lakehouse to GitHub OIDC repos

### DIFF
--- a/terraform.tfvars
+++ b/terraform.tfvars
@@ -24,4 +24,5 @@ repos = [
   "terraform-modules",
   "barbershop",
   "black-ruby",
+  "michael-mccarthy-lakehouse",
 ]


### PR DESCRIPTION
Adds `michael-mccarthy-lakehouse` to the OIDC repos list so Terraform provisions the `github-oidc-michael-mccarthy-lakehouse` role. This role lets the lakehouse infra repo authenticate to AWS from GitHub Actions (CI plan / CD apply).

**Blocks:** deploying the lakehouse infra repo, whose workflows assume `arn:aws:iam::004351562122:role/github-oidc-michael-mccarthy-lakehouse`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)