### PR TITLE
Rename OIDC repo entry michael-mccarthy-lakehouse -> michael-mccarthy-lake

### DIFF
--- a/terraform.tfvars
+++ b/terraform.tfvars
@@ -24,5 +24,5 @@ repos = [
   "terraform-modules",
   "barbershop",
   "black-ruby",
-  "michael-mccarthy-lakehouse",
+  "michael-mccarthy-lake",
 ]


### PR DESCRIPTION
Follow-up to #26. The lakehouse repo was renamed to `michael-mccarthy-lake`, so its OIDC role name and trust subject (`repo:mmccarthy404/michael-mccarthy-lake:*`) must match the new GitHub repo name.

This changes the `repos` entry from `michael-mccarthy-lakehouse` to `michael-mccarthy-lake`. On apply, Terraform destroys `github-oidc-michael-mccarthy-lakehouse` (created by #26 with the old name) and creates `github-oidc-michael-mccarthy-lake`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)