### PR TITLE
Add reddit-radar to OIDC repo roles

### DIFF
--- a/terraform.tfvars
+++ b/terraform.tfvars
@@ -25,4 +25,5 @@ repos = [
   "barbershop",
   "black-ruby",
   "michael-mccarthy-lake",
+  "reddit-radar",
 ]


### PR DESCRIPTION
Adds `reddit-radar` to the `repos` list so CD creates `github-oidc-reddit-radar`, letting the new repo's terraform CI/CD assume a role via GitHub OIDC.

Follows the existing repos-list pattern (admin inline policy, like every other repo role). **Follow-up:** scope these to least privilege per the best-practice rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)